### PR TITLE
add -contentImage option to TerminalNotifier

### DIFF
--- a/src/Notifier/TerminalNotifierNotifier.php
+++ b/src/Notifier/TerminalNotifierNotifier.php
@@ -47,6 +47,11 @@ class TerminalNotifierNotifier extends CliBasedNotifier
             $arguments[] = $notification->getIcon();
         }
 
+        if ($notification->getOption('contentImage')) {
+            $arguments[] = '-contentImage';
+            $arguments[] = $notification->getOption('contentImage');
+        }        
+
         if ($notification->getOption('url')) {
             $arguments[] = '-open';
             $arguments[] = $notification->getOption('url');


### PR DESCRIPTION
Related to https://github.com/jolicode/JoliNotif/issues/73

Since appIcon is no longer supported, there is this alternative to including an image using -contentImage and this PR adds the ability to set the appImage as an option.